### PR TITLE
ci(workspace): 🎡 dropped node 8 support, added 11

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 11.x, 12.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
husky@4x does support node 8, therefore, dropping support